### PR TITLE
show branches and repo in issue

### DIFF
--- a/app/views/issues/_changesets.html.erb
+++ b/app/views/issues/_changesets.html.erb
@@ -1,0 +1,19 @@
+<% changesets.each do |changeset| %>
+    <%
+        @repository = changeset.repository
+        @rev = changeset.identifier
+    %>
+    <div class="changeset <%= cycle('odd', 'even') %>">
+    <p>
+      <%= link_to_revision(changeset, changeset.repository, :text => "#{l(:label_revision)} #{changeset.format_identifier}") %>
+      @
+      <%= link_to(@repository.identifier, {:controller => 'repositories', :action => 'show', :id => @project, :repository_id => @repository.identifier, :path => to_path_param(@path)}) %>
+      (<em><%= l(:label_branch) %>: <%= links_to_branches.join(', ').html_safe %></em>)
+      <br/>
+      <span class="author"><%= authoring(changeset.committed_on, changeset.author) %></span>
+    </p>
+    <div class="wiki">
+        <%= textilizable(changeset, :comments) %>
+    </div>
+    </div>
+<% end %>


### PR DESCRIPTION
Great plugin!
Inspired by the discussion in http://www.redmine.org/issues/5386 I added support for branches and repository in the issue changeset view:

![bildschirmfoto 2015-04-04 um 18 32 04](https://cloud.githubusercontent.com/assets/365118/6993563/f6308d50-daf8-11e4-8917-9e0090dd8722.png)

Feel free to merge! :)

Cheers, Tobias
