### PR TITLE
Mercurial support

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,4 +1,5 @@
 require_dependency 'redmine_revision_branches/git_adapter_patch'
+require_dependency 'redmine_revision_branches/mercurial_adapter_patch'
 require_dependency 'redmine_revision_branches/repositories_helper_patch'
 
 Redmine::Plugin.register :redmine_revision_branches do

--- a/lib/redmine_revision_branches/mercurial_adapter_patch.rb
+++ b/lib/redmine_revision_branches/mercurial_adapter_patch.rb
@@ -1,0 +1,23 @@
+require 'redmine/scm/adapters/mercurial_adapter'
+
+module Redmine
+  module Scm
+    module Adapters
+      class MercurialAdapter
+        def branch_contains(hash)
+          cleaned_hash = hash.sub(/[^\w]/, '')
+          contains_filter = "descendants(%s) and heads(all()) and not closed()" % cleaned_hash
+          cmd_args = ['log', '-r', contains_filter, '-T', '{branch}\n']
+          begin
+            branches = hg(*cmd_args) do |io|
+              io.readlines.sort!.map{|t| t.strip.gsub(/\* ?/, '')}
+            end
+          rescue ScmCommandAborted
+            branches = Array.new
+          end
+          branches.uniq
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The change adds a corresponding adapter for the Mercurial SCM - through a very simple replacement using native filtering capability.

While there is a mercurial plugin (https://bitbucket.org/resi/hg-contains) that provides a similar functionality, it is not needed here.