### PR TITLE
fixed revision page rendering error on redmine 3.4

### DIFF
--- a/lib/redmine_revision_branches/repositories_helper_patch.rb
+++ b/lib/redmine_revision_branches/repositories_helper_patch.rb
@@ -24,18 +24,17 @@ RepositoriesHelper.class_eval do
 
   def insert_branches_detail(html)
     return html unless has_branch_detail?
-    substring = '</tr>'
+    substring = '</li>'
     location = html.index(substring).to_i + substring.length
     html.insert(location, branches_html)
   end
 
   def branches_html
-    content_tag(:tr) do
-      td = content_tag(:td, "#{l(:label_branch)}&nbsp;&nbsp;&nbsp;".html_safe, valign: 'top')
-      td << content_tag(:td) do
-        branch_html = content_tag(:b, "#{@repository.identifier}@ ")
-        branch_html << links_to_branches.join(', ').html_safe
-      end
+    content_tag(:li) do
+      content = content_tag(:strong, "#{l(:label_branch)}")
+      content << " "
+      content << "#{@repository.identifier}@ "
+      content << links_to_branches.join(', ').html_safe
     end
   end
 


### PR DESCRIPTION
Hi,

we've discovered a rendering bug in this plugin; see the attached screenshot for an illustration:

![bug](https://user-images.githubusercontent.com/6863569/30912171-d53d8c66-a38b-11e7-9959-8d03d42f532e.png)

I believe that this bug is caused by this upstream change: http://www.redmine.org/issues/23146

The plugin looks for a `<tr>` in the HTML output of the revision page, but the revision page now no longer contains a table. Unfortunately the code doesn't handle this at all; `html.index(substring).to_i` now results in 0, and therefore `location` is now 0 + 5 = 5, which means that the code inserts its HTML fragment right into the middle of a `<div>` element of the original HTML. I guess the proper fix would be to properly parse the HTML or at least catch situations where the tag can't be found, but my Ruby knowledge is very limited, so I didn't bother with a better fix :)

I've just replaced the match with `</li>` (the new formatting is now a `<ul>` list), and removed the `<td>`s from the generated markup. The results now looks like this:

![fix](https://user-images.githubusercontent.com/6863569/30912734-06e150d4-a38e-11e7-91b3-b9c01e5e764f.png)

This will break backwards compatibility to Redmine < 3.4 though. Hmm, maybe I should edit the code so that it'll work both with `</li>` and `</tr>`?