### PR TITLE
Subversion support.

### DIFF
--- a/app/views/issues/_changesets.html.erb
+++ b/app/views/issues/_changesets.html.erb
@@ -13,7 +13,7 @@
       <%= link_to_revision(changeset, changeset.repository, :text => "#{l(:label_revision)} #{changeset.format_identifier}") %>
 
 
-      <% if !!plugin_redmine_revision_branches('display_under_associated_revisions') && changeset.scmid.present?
+      <% if !!plugin_redmine_revision_branches('display_under_associated_revisions')
            @repository = changeset.repository
            @rev = changeset.identifier
       %>

--- a/app/views/redmine_revision_branches/_settings.html.erb
+++ b/app/views/redmine_revision_branches/_settings.html.erb
@@ -27,6 +27,11 @@
     <td>&nbsp;</td>
     <td>The associated revisions are found at the right of each Redmine ticket page.<br/><b>Warning:</b> enabling under associated revisions may slow down the performance of the Redmine ticket pages.</td>
   </tr>
+  <tr>
+    <td>
+    </td>
+    <td align="left">Prefix of subversion repository: <%= text_field_tag 'settings[svn_repos_prefix]', settings['svn_repos_prefix'], :size => '50' %></td>
+  </tr>
 
   </tbody>
 </table>

--- a/init.rb
+++ b/init.rb
@@ -1,5 +1,6 @@
 require_dependency 'redmine_revision_branches/git_adapter_patch'
 require_dependency 'redmine_revision_branches/mercurial_adapter_patch'
+require_dependency 'redmine_revision_branches/subversion_adapter_patch'
 require_dependency 'redmine_revision_branches/repositories_helper_patch'
 
 Redmine::Plugin.register :redmine_revision_branches do

--- a/lib/redmine_revision_branches/repositories_helper_patch.rb
+++ b/lib/redmine_revision_branches/repositories_helper_patch.rb
@@ -55,12 +55,20 @@ RepositoriesHelper.class_eval do
   end
 
   def branch_link(branch)
-    link_to(branch, {:controller => 'repositories',
-                     :action => 'show',
-                     :id => @repository.project,
-                     :repository_id => @repository.identifier,
-                     :path => to_path_param(@path),
-                     :rev => branch}).html_safe
+    if @repository.scm_name == 'Subversion'
+      link_to(branch, {:controller => 'repositories',
+                       :action => 'show',
+                       :id => @repository.project,
+                       :repository_id => @repository.identifier,
+                       :path => to_path_param(branch)}).html_safe
+    else
+      link_to(branch, {:controller => 'repositories',
+                       :action => 'show',
+                       :id => @repository.project,
+                       :repository_id => @repository.identifier,
+                       :path => to_path_param(@path),
+                       :rev => branch}).html_safe
+    end
   end
 
   def branch_groups

--- a/lib/redmine_revision_branches/subversion_adapter_patch.rb
+++ b/lib/redmine_revision_branches/subversion_adapter_patch.rb
@@ -1,0 +1,68 @@
+require 'redmine/scm/adapters/subversion_adapter'
+
+module Redmine
+  module Scm
+    module Adapters
+      class SubversionAdapter
+        BRANCHES_PREFIX = [{name: '/trunk',    next_count: 0},
+                           {name: '/branches', next_count: 1},
+                           {name: '/tags',     next_count: 1},
+                           {name: '/sandbox',  next_count: 1},
+                           {name: '',          next_count: 1}]
+
+        def svn_repos_prefix_settings
+          repos_prefix = Setting.plugin_redmine_revision_branches['svn_repos_prefix']
+          if repos_prefix.nil? or (repos_prefix == '')
+            settings = Array.new
+          else
+            settings = repos_prefix.split(',')
+          end
+          settings << ''
+        end
+
+        def get_branch_name(path)
+          svn_repos_prefix_settings.each do |repo|
+            BRANCHES_PREFIX.each do |branch_prefix|
+              pre = repo + branch_prefix[:name]
+              next if not path.start_with?(pre)
+
+              case branch_prefix[:next_count]
+              when 0
+                name = path.match(pre).to_s
+              when 1
+                path = path + '/'
+                name = path.match(pre + '\/(.*?)\/').to_s.chop
+              end
+              name.slice!(repo)
+              return name
+            end
+          end
+          return ''
+        end
+
+        def branch_contains(hash)
+          identifier = (hash && hash.to_i > 0) ? hash.to_i : "HEAD"
+          cmd = "#{self.class.sq_bin} log --xml -v -q -r #{identifier}"
+          cmd << credentials_string
+          cmd << ' ' + target
+          xml = ''
+          begin
+            shellout(cmd) do |io|
+              xml = parse_xml(io.read.force_encoding('UTF-8'))
+            end
+          rescue ScmCommandAborted
+          end
+
+          branches = Array.new
+          each_xml_element(xml['log'], 'logentry') do |logentry|
+            each_xml_element(logentry['paths'], 'path') do |path|
+              branches << get_branch_name(path['__content__'])
+            end if logentry['paths'] && logentry['paths']['path']
+          end
+          branches.select! {|b| b != ''}
+          branches.uniq
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This request is a feature to support Subversion repository on this plugin.
Image of issue page is following:
![revisions_on_issue](https://user-images.githubusercontent.com/378981/43042280-65c05e22-8db4-11e8-91a6-3888a0644bec.png)
And image of setting page.
![settings](https://user-images.githubusercontent.com/378981/43042312-2e568d98-8db5-11e8-90bb-a014f2e10834.png)


**Usage**
1. Check **Under Associated Revisions** on plugin configure page.
2. If your repository path is not root, set prefix of path to **Prefix of subversion repository** .
    It is able to set multiple prefix with comma delimiters.
      * For example, if your path to set on Redmine is http://svn.example.com/svn/project/subproject ,
        When http://svn.example.com/svn/project is root, you must set /subproject to **Prefix of subversion repository** .

Standard subversion structure (trunk, branches, tags) is supported.
And this patch recognizes **sandbox folder** because Redmine subversion repository has it.

